### PR TITLE
Jekyllコマンド実行時に生成されるディレクトリを無視する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata


### PR DESCRIPTION
Jekyllコマンド実行時に生成されるディレクトリがトラッキングされることを防ぐ